### PR TITLE
[DEV-5071] Replacing structKeyExists with looping as a filter first to speed up the tests

### DIFF
--- a/system/MockBox.cfc
+++ b/system/MockBox.cfc
@@ -618,13 +618,13 @@ Description		:
 			<cfreturn createObject("component","testbox.system.util.Util")/>
 		</cffunction>
 
-		<cffunction name="structKeyExistsWithLoop" access="public" output="false" returntype="boolean" hint="structKeyExists is very slow when objects mocked are large due to inheritance">
+		<cffunction name="structKeyExistsWithLoop" access="public" output="false" returntype="boolean" hint="structKeyExists is very slow when objects mocked are large due to inheritance and the key is not in the struct">
 			<cfargument name="object" 		type="any" required="true"  hint="The object taken as the struct for the key to be searched in"/>
 			<cfargument name="searchKey" 	type="string"  required="false" default="" hint="The key to search for" />
 			<cfscript>
 				for (key in object) {
 					if (key == searchKey) {
-						return not isNull(object[key]);
+						return structKeyExists(object, searchKey);
 					}
 				}
 				return false;

--- a/system/MockBox.cfc
+++ b/system/MockBox.cfc
@@ -114,8 +114,11 @@ Description		:
 			<cfargument name="callLogging" 	type="boolean" 	required="false" default="true" hint="Add method call logging for all mocked methods"/>
 			<!--- ************************************************************* --->
 			<cfscript>
-				if ( structKeyExists( arguments.object, "mockbox" ) ) {
-					return arguments.object;
+				// Note: The following takes very long for certain objects: if ( structKeyExists( arguments.object, "mockbox" ) ) {
+				for (key in arguments.object) {
+					if (key == 'mockbox') {
+						return arguments.object;
+					}
 				}
 				return createMock(object=arguments.object);
 			</cfscript>
@@ -357,13 +360,25 @@ Description		:
 				var genFile = "";
 				var oMockGenerator = this.MockBox.getmockGenerator();
 
+				var keyFound = false;
 				// Check if the method is existent in public scope
-				if ( structKeyExists(this,arguments.method) ){
-					fncMD = getMetadata(this[arguments.method]);
+				// Note: Using structKeyExists here takes a long time for certain objects:	if ( structKeyExists(this,arguments.method) ){
+				for (key in this) {
+					if (key == arguments.method) {
+						fncMD = getMetadata(this[arguments.method]);
+						keyFound = true;
+						break;	
+					}
 				}
+
 				// Else check in private scope
-				else if( structKeyExists(variables,arguments.method) ){
-					fncMD = getMetadata(variables[arguments.method]);
+				// Note: Using structKeyExists here takes a long time for certain objects: else if( structKeyExists(variables,arguments.method) ){
+				if (not keyFound) {
+					for (key in variables) {
+						if (key == arguments.method) {
+							fncMD = getMetadata(variables[arguments.method]);
+						}
+					}
 				}
 
 				// Prepare Metadata Existence, works on virtual methods also

--- a/system/MockBox.cfc
+++ b/system/MockBox.cfc
@@ -81,10 +81,10 @@ Description		:
 				var obj = 0;
 
 				// class to mock
-				if ( structKeyExists(arguments, "className") ){
+				if ( structKeyExistsWithLoop(arguments, "className") ){
 					obj = createObject("component",arguments.className);
 				}
-				else if ( structKeyExists(arguments, "object") ){
+				else if ( structKeyExistsWithLoop(arguments, "object") ){
 					// Object to Mock
 					obj = arguments.object;
 				}
@@ -114,12 +114,10 @@ Description		:
 			<cfargument name="callLogging" 	type="boolean" 	required="false" default="true" hint="Add method call logging for all mocked methods"/>
 			<!--- ************************************************************* --->
 			<cfscript>
-				// Note: The following takes very long for certain objects: if ( structKeyExists( arguments.object, "mockbox" ) ) {
-				for (key in arguments.object) {
-					if (key == 'mockbox') {
-						return arguments.object;
-					}
+				if (structKeyExistsWithLoop(arguments.object, 'mockbox')) {
+					return arguments.object;
 				}
+
 				return createMock(object=arguments.object);
 			</cfscript>
 		</cffunction>
@@ -162,11 +160,11 @@ Description		:
 			<cfscript>
 				var thisScope = evaluate( "#arguments.scope#" );
 
-				if( structKeyExists( thisScope, arguments.name ) ){
+				if( structKeyExistsWithLoop( thisScope, arguments.name ) ){
 					return thisScope[ arguments.name ];
 				}
 
-				if( structKeyExists( arguments, "default" ) ){
+				if( structKeyExistsWithLoop( arguments, "default" ) ){
 					return arguments.default;
 				}
 			</cfscript>
@@ -182,7 +180,7 @@ Description		:
 
 				// If method name used? Count only this method signatures
 				if( len(arguments.methodName) ){
-					if( structKeyExists(this._mockMethodCallCounters, arguments.methodName) ){
+					if( structKeyExistsWithLoop(this._mockMethodCallCounters, arguments.methodName) ){
 						return this._mockMethodCallCounters[arguments.methodName];
 					}
 					return -1;
@@ -303,10 +301,10 @@ Description		:
 					var args = arguments;
 					return this.$callback( function(){
 						throw(
-							type  		= structKeyExists( args, "type" ) ? args.type : "",
-							message  	= structKeyExists( args, "message" ) ? args.message : "",
-							detail  	= structKeyExists( args, "detail" ) ? args.detail : "",
-							errorCode 	= structKeyExists( args, "errorCode" ) ? args.errorCode : "0"
+							type  		= structKeyExistsWithLoop( args, "type" ) ? args.type : "",
+							message  	= structKeyExistsWithLoop( args, "message" ) ? args.message : "",
+							detail  	= structKeyExistsWithLoop( args, "detail" ) ? args.detail : "",
+							errorCode 	= structKeyExistsWithLoop( args, "errorCode" ) ? args.errorCode : "0"
 						);
 					} );
 				}
@@ -362,33 +360,20 @@ Description		:
 
 				var keyFound = false;
 				// Check if the method is existent in public scope
-				// Note: Using structKeyExists here takes a long time for certain objects:	if ( structKeyExists(this,arguments.method) ){
-				for (key in this) {
-					if (key == arguments.method) {
-						fncMD = getMetadata(this[arguments.method]);
-						keyFound = true;
-						break;	
-					}
-				}
-
-				// Else check in private scope
-				// Note: Using structKeyExists here takes a long time for certain objects: else if( structKeyExists(variables,arguments.method) ){
-				if (not keyFound) {
-					for (key in variables) {
-						if (key == arguments.method) {
-							fncMD = getMetadata(variables[arguments.method]);
-						}
-					}
+				if ( structKeyExistsWithLoop(this,arguments.method) ) {
+					fncMD = getMetadata(this[arguments.method]);
+				} else if( structKeyExistsWithLoop(variables,arguments.method) ){
+					fncMD = getMetadata(variables[arguments.method]);
 				}
 
 				// Prepare Metadata Existence, works on virtual methods also
-				if ( not structKeyExists(fncMD,"returntype") ){
+				if ( not structKeyExistsWithLoop(fncMD,"returntype") ){
 					fncMD["returntype"] = "any";
 				}
-				if ( not structKeyExists(fncMD,"access") ){
+				if ( not structKeyExistsWithLoop(fncMD,"access") ){
 					fncMD["access"] = "public";
 				}
-				if( not structKeyExists(fncMD,"output") ){
+				if( not structKeyExistsWithLoop(fncMD,"output") ){
 					fncMD["output"] = true;
 				}
 				// Preserve Return Type?
@@ -406,7 +391,7 @@ Description		:
 				oMockGenerator.generate( argumentCollection=arguments );
 
 				// Results Setup For No Argument Definitions or base results
-				if( structKeyExists( arguments, "returns" ) ){
+				if( structKeyExistsWithLoop( arguments, "returns" ) ){
 					this._mockResults[ arguments.method ] = ArrayNew( 1 );
 					this._mockResults[ arguments.method ][ 1 ] = arguments.returns;
 				}
@@ -415,7 +400,7 @@ Description		:
 				}
 
 				// Callbacks Setup For No Argument Definitions or base results
-				if( structKeyExists( arguments, "callback" ) ){
+				if( structKeyExistsWithLoop( arguments, "callback" ) ){
 					this._mockCallbacks[ arguments.method ] = ArrayNew( 1 );
 					this._mockCallbacks[ arguments.method ][ 1 ] = arguments.callback;
 				}
@@ -530,7 +515,7 @@ Description		:
 				var serializedArgs = "";
 
 				for( var arg in argOrderedTree ){
-					if( NOT structKeyExists( argOrderedTree, arg ) ){
+					if( NOT structKeyExistsWithLoop( argOrderedTree, arg ) ){
 						/* we aren't going to be able to serialize an undefined variable, this might occur if an arguments structure
 						 * containing optional parameters is passed by argumentCollection=arguments to the mocked method.
 						 */
@@ -551,7 +536,7 @@ Description		:
 					else if(
 						isObject( argOrderedTree[ arg ] ) and
 						// Find out if object, sometimes of course, on Adobe, is instance does not work, so sucky
-						( isInstanceOf( argOrderedTree[ arg ], "Component" ) OR structKeyExists( getMetadata( argOrderedTree[ arg ] ), "extends" ) )
+						( isInstanceOf( argOrderedTree[ arg ], "Component" ) OR structKeyExistsWithLoop( getMetadata( argOrderedTree[ arg ] ), "extends" ) )
 					){
 						// If an object and CFC, just use serializeJSON
 						serializedArgs &= serializeJSON( getMetadata( argOrderedTree[ arg ] ) );
@@ -632,5 +617,19 @@ Description		:
 		<cffunction name="getUtil" access="private" output="false" returntype="testbox.system.util.Util" hint="Create and return a util object">
 			<cfreturn createObject("component","testbox.system.util.Util")/>
 		</cffunction>
+
+		<cffunction name="structKeyExistsWithLoop" access="private" output="false" returntype="boolean" hint="structKeyExists is very slow when objects mocked are large due to inheritance">
+			<cfargument name="object" 		type="any" required="true"  hint="The object taken as the struct for the key to be searched in"/>
+			<cfargument name="searchKey" 	type="string"  required="false" default="" hint="The key to search for" />
+			<cfscript>
+				for (key in object) {
+					if (key == searchKey) [
+						return true;
+					]
+				}
+				return false;
+			</cfscript>
+		</cffunction>
+
 
 	</cfcomponent>

--- a/system/MockBox.cfc
+++ b/system/MockBox.cfc
@@ -160,11 +160,11 @@ Description		:
 			<cfscript>
 				var thisScope = evaluate( "#arguments.scope#" );
 
-				if( structKeyExistsWithLoop( thisScope, arguments.name ) ){
+				if( this.MockBox.structKeyExistsWithLoop( thisScope, arguments.name ) ){
 					return thisScope[ arguments.name ];
 				}
 
-				if( structKeyExistsWithLoop( arguments, "default" ) ){
+				if( this.MockBox.structKeyExistsWithLoop( arguments, "default" ) ){
 					return arguments.default;
 				}
 			</cfscript>
@@ -180,7 +180,7 @@ Description		:
 
 				// If method name used? Count only this method signatures
 				if( len(arguments.methodName) ){
-					if( structKeyExistsWithLoop(this._mockMethodCallCounters, arguments.methodName) ){
+					if( this.MockBox.structKeyExistsWithLoop(this._mockMethodCallCounters, arguments.methodName) ){
 						return this._mockMethodCallCounters[arguments.methodName];
 					}
 					return -1;
@@ -301,10 +301,10 @@ Description		:
 					var args = arguments;
 					return this.$callback( function(){
 						throw(
-							type  		= structKeyExistsWithLoop( args, "type" ) ? args.type : "",
-							message  	= structKeyExistsWithLoop( args, "message" ) ? args.message : "",
-							detail  	= structKeyExistsWithLoop( args, "detail" ) ? args.detail : "",
-							errorCode 	= structKeyExistsWithLoop( args, "errorCode" ) ? args.errorCode : "0"
+							type  		= this.MockBox.structKeyExistsWithLoop( args, "type" ) ? args.type : "",
+							message  	= this.MockBox.structKeyExistsWithLoop( args, "message" ) ? args.message : "",
+							detail  	= this.MockBox.structKeyExistsWithLoop( args, "detail" ) ? args.detail : "",
+							errorCode 	= this.MockBox.structKeyExistsWithLoop( args, "errorCode" ) ? args.errorCode : "0"
 						);
 					} );
 				}
@@ -360,20 +360,20 @@ Description		:
 
 				var keyFound = false;
 				// Check if the method is existent in public scope
-				if ( structKeyExistsWithLoop(this,arguments.method) ) {
+				if ( this.MockBox.structKeyExistsWithLoop(this,arguments.method) ) {
 					fncMD = getMetadata(this[arguments.method]);
-				} else if( structKeyExistsWithLoop(variables,arguments.method) ){
+				} else if( this.MockBox.structKeyExistsWithLoop(variables,arguments.method) ){
 					fncMD = getMetadata(variables[arguments.method]);
 				}
 
 				// Prepare Metadata Existence, works on virtual methods also
-				if ( not structKeyExistsWithLoop(fncMD,"returntype") ){
+				if ( not this.MockBox.structKeyExistsWithLoop(fncMD,"returntype") ){
 					fncMD["returntype"] = "any";
 				}
-				if ( not structKeyExistsWithLoop(fncMD,"access") ){
+				if ( not this.MockBox.structKeyExistsWithLoop(fncMD,"access") ){
 					fncMD["access"] = "public";
 				}
-				if( not structKeyExistsWithLoop(fncMD,"output") ){
+				if( not this.MockBox.structKeyExistsWithLoop(fncMD,"output") ){
 					fncMD["output"] = true;
 				}
 				// Preserve Return Type?
@@ -391,7 +391,7 @@ Description		:
 				oMockGenerator.generate( argumentCollection=arguments );
 
 				// Results Setup For No Argument Definitions or base results
-				if( structKeyExistsWithLoop( arguments, "returns" ) ){
+				if( this.MockBox.structKeyExistsWithLoop( arguments, "returns" ) ){
 					this._mockResults[ arguments.method ] = ArrayNew( 1 );
 					this._mockResults[ arguments.method ][ 1 ] = arguments.returns;
 				}
@@ -400,7 +400,7 @@ Description		:
 				}
 
 				// Callbacks Setup For No Argument Definitions or base results
-				if( structKeyExistsWithLoop( arguments, "callback" ) ){
+				if( this.MockBox.structKeyExistsWithLoop( arguments, "callback" ) ){
 					this._mockCallbacks[ arguments.method ] = ArrayNew( 1 );
 					this._mockCallbacks[ arguments.method ][ 1 ] = arguments.callback;
 				}
@@ -618,14 +618,14 @@ Description		:
 			<cfreturn createObject("component","testbox.system.util.Util")/>
 		</cffunction>
 
-		<cffunction name="structKeyExistsWithLoop" access="private" output="false" returntype="boolean" hint="structKeyExists is very slow when objects mocked are large due to inheritance">
+		<cffunction name="structKeyExistsWithLoop" access="public" output="false" returntype="boolean" hint="structKeyExists is very slow when objects mocked are large due to inheritance">
 			<cfargument name="object" 		type="any" required="true"  hint="The object taken as the struct for the key to be searched in"/>
 			<cfargument name="searchKey" 	type="string"  required="false" default="" hint="The key to search for" />
 			<cfscript>
 				for (key in object) {
-					if (key == searchKey) [
-						return true;
-					]
+					if (key == searchKey) {
+						return not isNull(object[key]);
+					}
 				}
 				return false;
 			</cfscript>

--- a/system/util/MixerUtil.cfc
+++ b/system/util/MixerUtil.cfc
@@ -42,9 +42,9 @@ Description :
 		<cfargument name="CFC" required="true" hint="The cfc to mixin">
 		<cfset var udf = 0>
 
-		<cfif NOT structKeyExistsLocal(arguments.CFC, "$mixed")>
+		<cfif NOT structKeyExists(arguments.CFC, "$mixed")>
 		<cflock name="mixerUtil.#instance.system.identityHashCode(arguments.CFC)#" type="exclusive" timeout="15" throwontimeout="true">
-			<cfif NOT structKeyExistsLocal(arguments.CFC, "$mixed")>
+			<cfif NOT structKeyExists(arguments.CFC, "$mixed")>
 			<cfscript>
 				for( udf in instance.mixins ){
 					arguments.CFC[udf] = instance.mixins[udf];
@@ -54,20 +54,6 @@ Description :
 			</cfif>
 		</cflock>
 		</cfif>
-	</cffunction>
-
-	<cffunction name="structKeyExistsLocal">
-		<cfargument name="object" required="true">
-		<cfargument name="searchKey" required="true">
-
-		<cfscript>
-			for ( key in object ) {
-				if (key == searchKey) {
-					return true;
-				}
-			}
-			return false;
-		</cfscript>
 	</cffunction>
 
 	<!--- Stop the injection, do cleanup --->

--- a/system/util/MixerUtil.cfc
+++ b/system/util/MixerUtil.cfc
@@ -42,9 +42,9 @@ Description :
 		<cfargument name="CFC" required="true" hint="The cfc to mixin">
 		<cfset var udf = 0>
 
-		<cfif NOT structKeyExists(arguments.CFC, "$mixed")>
+		<cfif NOT structKeyExistsLocal(arguments.CFC, "$mixed")>
 		<cflock name="mixerUtil.#instance.system.identityHashCode(arguments.CFC)#" type="exclusive" timeout="15" throwontimeout="true">
-			<cfif NOT structKeyExists(arguments.CFC, "$mixed")>
+			<cfif NOT structKeyExistsLocal(arguments.CFC, "$mixed")>
 			<cfscript>
 				for( udf in instance.mixins ){
 					arguments.CFC[udf] = instance.mixins[udf];
@@ -54,6 +54,20 @@ Description :
 			</cfif>
 		</cflock>
 		</cfif>
+	</cffunction>
+
+	<cffunction name="structKeyExistsLocal">
+		<cfargument name="object" required="true">
+		<cfargument name="searchKey" required="true">
+
+		<cfscript>
+			for ( key in object ) {
+				if (key == searchKey) {
+					return true;
+				}
+			}
+			return false;
+		</cfscript>
 	</cffunction>
 
 	<!--- Stop the injection, do cleanup --->


### PR DESCRIPTION

When objects mocked are large objects, calling structKeyExists with a key that is not defined in the object takes a long time. This optimization uses a looping to prevent calling structKeyExists if the key is not in the object via a for loop.

This gives ~25 seconds saving on repeat test runs on my local machine:

before:

![image](https://user-images.githubusercontent.com/34229366/79328101-34cfc700-7f1e-11ea-9600-cc53c7db3a92.png)

vs.

after
![image](https://user-images.githubusercontent.com/34229366/79328118-38634e00-7f1e-11ea-80f8-918235a3b2fa.png)
